### PR TITLE
Only get sys.argv if it doesn't already exist

### DIFF
--- a/include/henson/python-puppet.hpp
+++ b/include/henson/python-puppet.hpp
@@ -61,7 +61,12 @@ struct PythonPuppet: public Coroutine<PythonPuppet>
                 self->start_time_ = get_time();
                 try
                 {
-                    auto argv = py::module::import("sys").attr("argv");
+                    py::list argv;
+                    if (py::hasattr(py::module::import("sys"), "argv")) {
+                        argv = py::module::import("sys").attr("argv");
+                    } else {
+                        py::module::import("sys").add_object("argv", argv);
+                    }
                     argv.attr("clear")();
                     for(size_t i = 0; i < self->arguments_.size(); ++i)
                     {


### PR DESCRIPTION
This fixes a Python exception that occurs when trying to get Python's `sys.argv` when it doesn't already exist (Issue #2).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/henson-insitu/henson/3)
<!-- Reviewable:end -->
